### PR TITLE
refactor: Indent using tabs instead of spaces as default

### DIFF
--- a/src/components/UVLEditor.jsx
+++ b/src/components/UVLEditor.jsx
@@ -123,6 +123,10 @@ function UVLEditor({ editorRef, validateModel, defaultCode = "", hide }) {
           value={defaultCode}
           onMount={handleEditorDidMount}
           onChange={validateModel}
+          options={{
+            insertSpaces: false,
+            tabSize: 4,
+          }}
         />
       </div>
     </div>


### PR DESCRIPTION
Most UVL models are defined using tabs (\t) as indentation. and this PR updates the editor instance to indent using tabs instead of spaces as a default. This behavior can be changed by pressing F1 while the editor is active, and typing "indent using <option>".
![image](https://github.com/user-attachments/assets/4e4aa4d0-0d60-42c4-976e-5be908e9143d)

Then, users can select which style they prefer. It is important that indentation is the same throughout the entire code
